### PR TITLE
Preliminary support for supported-filetypes templates

### DIFF
--- a/marda_extractors_api/__init__.py
+++ b/marda_extractors_api/__init__.py
@@ -231,7 +231,7 @@ class MardaExtractor:
         template = None
         for filetype in self.entry["supported_filetypes"]:
             if filetype["id"] == input_type:
-                template = filetype.get("template", {})
+                template = filetype.get("template")
                 break
         else:
             raise ValueError(
@@ -427,6 +427,8 @@ class MardaExtractor:
         default_fields = {"input_type", "input_path", "output_type", "output_path"}
         for field in default_fields:
             value = additional_template.get(field) or locals()[field]
+            if value is None:
+                continue
             if method == SupportedExecutionMethod.CLI:
                 command = command.replace(f"{{{{ {field} }}}}", str(value))
             else:

--- a/marda_extractors_api/__init__.py
+++ b/marda_extractors_api/__init__.py
@@ -432,14 +432,6 @@ class MardaExtractor:
             else:
                 command = command.replace(f"{{{{ {field} }}}}", f"{str(value)!r}")
 
-        for field in additional_template:
-            if field not in default_fields:
-                value = additional_template[field]
-                if method == SupportedExecutionMethod.CLI:
-                    command = command.replace(f"{{{{ {field} }}}}", str(value))
-                else:
-                    command = command.replace(f"{{{{ {field} }}}}", f"{str(value)!r}")
-
         return command
 
     @staticmethod


### PR DESCRIPTION
Closes #22.

Not sure how this was missing, but now the `template` in  `supported_filetypes` will be respected.